### PR TITLE
fix broken seek bar

### DIFF
--- a/src/app/nowplaying/nowplaying.js
+++ b/src/app/nowplaying/nowplaying.js
@@ -129,7 +129,7 @@ angular.module('moped.nowplaying', [
   function seek(sliderValue) {
     if ($scope.currentTrackLength > 0) {
       var milliSeconds = ($scope.currentTrackLength / 100) * sliderValue;
-      mopidyservice.seek(milliSeconds);      
+      mopidyservice.seek(milliSeconds >> 0);      
     }
   }
 


### PR DESCRIPTION
truncate `milliSeconds` in seek function. Mopidy requires integer values, not floating point values
